### PR TITLE
some small improvements and a basic command line interface

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+tab_width = 4
+
+[*.rs]
+indent_style = tab

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "clap"
+version = "4.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +217,7 @@ name = "markdoll"
 version = "0.1.0"
 dependencies = [
  "ariadne",
+ "clap",
  "downcast-rs",
  "env_logger",
  "hashbrown",
@@ -236,6 +283,12 @@ name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 description = "a structured and extensible markup language"
 readme = "README.md"
 repository = "https://github.com/0x57e11a/markdoll"
+rust-version = "1.81"
 license = "MIT"
 keywords = ["markup"]
 categories = ["compilers", "no-std", "parser-implementations", "visualization"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,13 @@ downcast-rs = "1.2.1"
 log = "0.4.22"
 env_logger = "0.11.5"
 ariadne = { version = "0.4.1", optional = true }
+clap = { version = "4.5.17", features = ["derive"], optional = true }
 
 [features]
 default = []
 ariadne = ["dep:ariadne"]
+cli = ["dep:clap", "ariadne"]
+
+[[bin]]
+name = "markdoll"
+required-features = ["cli"]

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ to get an idea of the syntax, [visit the repository](https://github.com/0x57e11a
 
 - `ariadne`
   allows fancy diagnostic printing, requires `std`
+
+## minimum supported rust version
+
+this library requires features from rust 1.81

--- a/spec.doll
+++ b/spec.doll
@@ -61,7 +61,7 @@
 				block content allows far more flexibility in the content of tags, being able to put anything inside of them,
 				without markdoll interpreting it whatsoever, leaving that to that tag
 
-				however, this requires that the content
+				however, this requires that the content is indented one level further than the tag, to let the parser know what is and is not part of the content
 			]
 		&escape sequences
 			most parts of markdoll support escape sequences with the backslash character ([code:\\])
@@ -89,6 +89,7 @@
 						-	[em:can also include formatting]
 						-	lists can also
 							span multiple lines
+							if the same indent is kept
 
 				-	=	ordered
 					-	[codeblock(doll)::
@@ -102,6 +103,7 @@
 						=	[em:can also include formatting]
 						=	lists can also
 							span multiple lines
+							if the same indent is kept
 			]
 		&sections
 			a section is preceded by a heading, and its content is indented 1 level higher

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,85 @@
+#![cfg(feature = "cli")]
+
+use std::io::Read;
+
+use clap::{Parser, Subcommand};
+use markdoll::MarkDoll;
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Cli {
+	#[command(subcommand)]
+	command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+	/// check the provided stdin and print any parsing errors
+	Check,
+	/// convert the provided stdin to html and output to stdout
+	Convert,
+}
+
+fn main() {
+	env_logger::init();
+
+	let args = Cli::parse();
+
+	let mut src = String::new();
+
+	std::io::stdin()
+		.read_to_string(&mut src)
+		.expect("failed to read stdin");
+
+	let mut out = String::new();
+
+	let mut doll = MarkDoll::new();
+	doll.ext_system.add_tags(markdoll::ext::common::TAGS);
+	doll.ext_system.add_tags(markdoll::ext::formatting::TAGS);
+	doll.ext_system.add_tags(markdoll::ext::code::TAGS);
+	doll.ext_system.add_tags(markdoll::ext::links::TAGS);
+	doll.ext_system.add_tags(markdoll::ext::table::TAGS);
+
+	log::info!("parse");
+
+	let mut ok = true;
+
+	match doll.parse(&src) {
+		Ok(mut ast) => match args.command {
+			Command::Check => {
+				log::info!("parse succeeded")
+			}
+			Command::Convert => {
+				log::info!("emitting");
+
+				if doll.emit(&mut ast, &mut out) {
+					log::info!("output written to stdout");
+
+					print!("{}", out);
+				} else {
+					log::error!("emit failed");
+					ok = false;
+				}
+			}
+		},
+		Err(_) => {
+			log::error!("parse failed");
+			ok = false;
+		}
+	}
+
+	log::info!("diagnostics");
+
+	let mut cache = ariadne::Source::from(&src);
+
+	for report in markdoll::diagnostics::render(&doll.finish()) {
+		report.eprint(&mut cache).unwrap();
+	}
+
+	if ok {
+		log::info!("end");
+	} else {
+		log::error!("failed");
+		std::process::exit(1);
+	}
+}


### PR DESCRIPTION
the commit messages should be fairly self explanatory, but:

- the editorconfig can be added to gitignore instead if desired
- the cli is very simple and only works with stdin/stdout for now, to use it `cargo run --features=cli`
- there is a FIXME comment left in a part of the spec where something looks missing